### PR TITLE
made the return type more typesafe

### DIFF
--- a/src/core/yaku/Riichi.test.ts
+++ b/src/core/yaku/Riichi.test.ts
@@ -2,10 +2,23 @@ import { describe, it, expect } from 'vitest';
 
 import { Riichi } from './Riichi';
 import { hasYaku, getYaku } from './YakuHelpers';
-import type { YakuName, RiichiCalcResult } from './YakuTypes';
+import {
+  type YakuName,
+  type AgariResult,
+  type CalcResult,
+  CalcResultType,
+} from './YakuTypes';
+
+export const assertAgariResult: (
+  result: CalcResult,
+) => asserts result is AgariResult = (result: CalcResult) => {
+  if (result.type !== CalcResultType.AGARI) {
+    throw new Error(`Expected agari result but got ${result.type}`);
+  }
+};
 
 const expectYaku = (
-  result: RiichiCalcResult,
+  result: AgariResult,
   name: YakuName,
   expectedValue:
     | { type: 'han'; count: number }
@@ -20,6 +33,8 @@ describe('Basic Examples', () => {
   it('usage', () => {
     const riichi = new Riichi('112233456789m11s');
     const result = riichi.calc();
+    assertAgariResult(result);
+    expect(result.type).toBe('agari');
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(0);
     expect(result.han).toBe(4);
@@ -55,6 +70,7 @@ describe('役満 (Yakuman)', () => {
   it('国士無双', () => {
     const riichi = new Riichi('11m19p19s1234567z9m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -70,6 +86,7 @@ describe('役満 (Yakuman)', () => {
   it('国士無双十三面待ち', () => {
     const riichi = new Riichi('19m19p19s1234567z7z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(2);
     expect(
@@ -85,6 +102,7 @@ describe('役満 (Yakuman)', () => {
   it('九蓮宝燈', () => {
     const riichi = new Riichi('1111234678999m5m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -100,6 +118,7 @@ describe('役満 (Yakuman)', () => {
   it('純正九蓮宝燈', () => {
     const riichi = new Riichi('1112345678999m9m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(2);
     expect(
@@ -115,6 +134,7 @@ describe('役満 (Yakuman)', () => {
   it('四暗刻', () => {
     const riichi = new Riichi('111222333m4455p4p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -130,6 +150,7 @@ describe('役満 (Yakuman)', () => {
   it('四暗刻単騎待ち', () => {
     const riichi = new Riichi('111222333444m55m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(2);
     expect(
@@ -145,6 +166,7 @@ describe('役満 (Yakuman)', () => {
   it('大三元', () => {
     const riichi = new Riichi('555666777z77p+111m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -160,6 +182,7 @@ describe('役満 (Yakuman)', () => {
   it('小四喜', () => {
     const riichi = new Riichi('111222333z44z+555p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -175,6 +198,7 @@ describe('役満 (Yakuman)', () => {
   it('大四喜', () => {
     const riichi = new Riichi('111222333z11p+444z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(2);
     expect(
@@ -190,6 +214,7 @@ describe('役満 (Yakuman)', () => {
   it('字一色', () => {
     const riichi = new Riichi('11122244466z+555z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -205,6 +230,7 @@ describe('役満 (Yakuman)', () => {
   it('緑一色', () => {
     const riichi = new Riichi('222333444s88s+666z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -220,6 +246,7 @@ describe('役満 (Yakuman)', () => {
   it('清老頭', () => {
     const riichi = new Riichi('111999m11199s+999p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -235,6 +262,7 @@ describe('役満 (Yakuman)', () => {
   it('四槓子', () => {
     const riichi = new Riichi('5z+1111m+2222p+3333s+4444z+5z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -250,6 +278,7 @@ describe('役満 (Yakuman)', () => {
   it('天和', () => {
     const riichi = new Riichi('112233456789m11s+t1');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -265,6 +294,7 @@ describe('役満 (Yakuman)', () => {
   it('地和', () => {
     const riichi = new Riichi('112233456789m11s+t2');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(1);
     expect(
@@ -281,6 +311,7 @@ describe('役満 (Yakuman)', () => {
     // 字一色 大四喜 四槓子 四暗刻単騎
     const riichi = new Riichi('5z+11z+22z+33z+44z+5z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(6);
   });
@@ -290,6 +321,7 @@ describe('3-6飜役', () => {
   it('清一色', () => {
     const riichi = new Riichi('112233456789m11m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '清一色', { type: 'han', count: 6 });
   });
@@ -297,6 +329,7 @@ describe('3-6飜役', () => {
   it('清一色(食い下がり)', () => {
     const riichi = new Riichi('1234567811m9m+123m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '清一色', { type: 'han', count: 5 });
   });
@@ -304,6 +337,7 @@ describe('3-6飜役', () => {
   it('混一色', () => {
     const riichi = new Riichi('123456m111222z33z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '混一色', { type: 'han', count: 3 });
   });
@@ -311,6 +345,7 @@ describe('3-6飜役', () => {
   it('二盃口', () => {
     const riichi = new Riichi('112233445566m77m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '二盃口', { type: 'han', count: 3 });
   });
@@ -318,6 +353,7 @@ describe('3-6飜役', () => {
   it('純全帯么九', () => {
     const riichi = new Riichi('123789m123789p99s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '純全帯么九', { type: 'han', count: 3 });
   });
@@ -327,6 +363,7 @@ describe('2飜役', () => {
   it('混全帯么九', () => {
     const riichi = new Riichi('123789m111z999p11z');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '混全帯么九', { type: 'han', count: 2 });
   });
@@ -334,6 +371,7 @@ describe('2飜役', () => {
   it('対々和', () => {
     const riichi = new Riichi('111222m444p5p5p+333m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '対々和', { type: 'han', count: 2 });
   });
@@ -341,6 +379,7 @@ describe('2飜役', () => {
   it('混老頭', () => {
     const riichi = new Riichi('111999m111p11z+999p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '混老頭', { type: 'han', count: 2 });
   });
@@ -348,6 +387,7 @@ describe('2飜役', () => {
   it('三槓子', () => {
     const riichi = new Riichi('456m11p+50m+2222p+3333s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '三槓子', { type: 'han', count: 2 });
   });
@@ -355,6 +395,7 @@ describe('2飜役', () => {
   it('小三元', () => {
     const riichi = new Riichi('555666z77z123456m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '小三元', { type: 'han', count: 2 });
   });
@@ -362,6 +403,7 @@ describe('2飜役', () => {
   it('三色同刻', () => {
     const riichi = new Riichi('222m222p222s34577s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '三色同刻', { type: 'han', count: 2 });
   });
@@ -369,6 +411,7 @@ describe('2飜役', () => {
   it('三暗刻', () => {
     const riichi = new Riichi('111222333m456p77p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '三暗刻', { type: 'han', count: 2 });
   });
@@ -376,6 +419,7 @@ describe('2飜役', () => {
   it('七対子', () => {
     const riichi = new Riichi('112233m445566z77m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '七対子', { type: 'han', count: 2 });
   });
@@ -383,6 +427,7 @@ describe('2飜役', () => {
   it('ダブル立直', () => {
     const riichi = new Riichi('112233456789m11s+w');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, 'ダブル立直', { type: 'han', count: 2 });
   });
@@ -390,6 +435,7 @@ describe('2飜役', () => {
   it('一気通貫', () => {
     const riichi = new Riichi('123456789m111p22p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '一気通貫', { type: 'han', count: 2 });
   });
@@ -397,6 +443,7 @@ describe('2飜役', () => {
   it('三色同順', () => {
     const riichi = new Riichi('123m123p123s34577s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '三色同順', { type: 'han', count: 2 });
   });
@@ -406,6 +453,7 @@ describe('1飜役', () => {
   it('断么九', () => {
     const riichi = new Riichi('222333444m567m88m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '断么九', { type: 'han', count: 1 });
   });
@@ -413,6 +461,7 @@ describe('1飜役', () => {
   it('平和', () => {
     const riichi = new Riichi('123456789m23444m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '平和', { type: 'han', count: 1 });
   });
@@ -420,6 +469,7 @@ describe('1飜役', () => {
   it('一盃口', () => {
     const riichi = new Riichi('112233m456789p55p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '一盃口', { type: 'han', count: 1 });
   });
@@ -427,6 +477,7 @@ describe('1飜役', () => {
   it('門前清自摸和', () => {
     const riichi = new Riichi('112233456789m11s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '門前清自摸和', { type: 'han', count: 1 });
   });
@@ -434,6 +485,7 @@ describe('1飜役', () => {
   it('立直', () => {
     const riichi = new Riichi('112233456789m11s+r');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '立直', { type: 'han', count: 1 });
   });
@@ -441,6 +493,7 @@ describe('1飜役', () => {
   it('一発', () => {
     const riichi = new Riichi('112233456789m11s+i');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '一発', { type: 'han', count: 1 });
   });
@@ -448,6 +501,7 @@ describe('1飜役', () => {
   it('嶺上開花', () => {
     const riichi = new Riichi('234567p888s99s+22m+k');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '嶺上開花', { type: 'han', count: 1 });
   });
@@ -455,6 +509,7 @@ describe('1飜役', () => {
   it('搶槓', () => {
     const riichi = new Riichi('112233456789m1s+1s+k');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '搶槓', { type: 'han', count: 1 });
   });
@@ -462,6 +517,7 @@ describe('1飜役', () => {
   it('海底摸月', () => {
     const riichi = new Riichi('112233456789m11s+h');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '海底摸月', { type: 'han', count: 1 });
   });
@@ -469,6 +525,7 @@ describe('1飜役', () => {
   it('河底撈魚', () => {
     const riichi = new Riichi('112233456789m1s+h+1s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '河底撈魚', { type: 'han', count: 1 });
   });
@@ -476,6 +533,7 @@ describe('1飜役', () => {
   it('場風東', () => {
     const riichi = new Riichi('111z234567m888p99p+1');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '場風東', { type: 'han', count: 1 });
   });
@@ -483,6 +541,7 @@ describe('1飜役', () => {
   it('自風東', () => {
     const riichi = new Riichi('111z234567m888p99p+1');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '自風東', { type: 'han', count: 1 });
   });
@@ -490,6 +549,7 @@ describe('1飜役', () => {
   it('役牌白', () => {
     const riichi = new Riichi('555z123456m789p11p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '役牌白', { type: 'han', count: 1 });
   });
@@ -497,6 +557,7 @@ describe('1飜役', () => {
   it('役牌発', () => {
     const riichi = new Riichi('666z123456m789p11p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '役牌発', { type: 'han', count: 1 });
   });
@@ -504,6 +565,7 @@ describe('1飜役', () => {
   it('役牌中', () => {
     const riichi = new Riichi('777z123456m789p11p');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '役牌中', { type: 'han', count: 1 });
   });
@@ -513,6 +575,7 @@ describe('ドラ (Dora)', () => {
   it('ドラ1枚', () => {
     const riichi = new Riichi('112233456789m11s+d9m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, 'ドラ', { type: 'han', count: 1 });
   });
@@ -520,6 +583,7 @@ describe('ドラ (Dora)', () => {
   it('赤ドラ1枚', () => {
     const riichi = new Riichi('11223340678m9m99s');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '赤ドラ', { type: 'han', count: 1 });
   });
@@ -527,6 +591,7 @@ describe('ドラ (Dora)', () => {
   it('裏ドラ1枚(立直時)', () => {
     const riichi = new Riichi('112233456789m11s+r+d8m+u9m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '立直', { type: 'han', count: 1 });
     expectYaku(result, 'ドラ', { type: 'han', count: 1 });
@@ -536,6 +601,7 @@ describe('ドラ (Dora)', () => {
   it('裏ドラなし(立直なし)', () => {
     const riichi = new Riichi('112233456789m11s+u9m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(hasYaku(result.yaku, '裏ドラ')).toBe(false);
   });
@@ -543,9 +609,73 @@ describe('ドラ (Dora)', () => {
   it('裏ドラのみ(立直時)', () => {
     const riichi = new Riichi('112233456789m11s+r+d9m+u1m');
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expectYaku(result, '立直', { type: 'han', count: 1 });
     expectYaku(result, 'ドラ', { type: 'han', count: 1 });
     expectYaku(result, '裏ドラ', { type: 'han', count: 2 });
+  });
+});
+
+describe('Type Guard Tests', () => {
+  it('should discriminate AgariResult with type field', () => {
+    const riichi = new Riichi('112233456789m11s');
+    const result = riichi.calc();
+
+    if (result.type === CalcResultType.AGARI) {
+      expect(result.isAgari).toBe(true);
+      expect(result.error).toBe(false);
+      expect(result.han).toBe(4);
+      expect(result.ten).toBe(7900);
+      expect('hairi' in result).toBe(false);
+    } else {
+      throw new Error('Expected agari result');
+    }
+  });
+
+  it('should discriminate NotenResult with type field', () => {
+    const riichi = new Riichi('1112345678999m');
+    const result = riichi.calc();
+
+    if (result.type === CalcResultType.NOTEN) {
+      expect(result.isAgari).toBe(false);
+      expect(result.error).toBe(false);
+      expect(result.hairi).toBeDefined();
+      expect(result.hairi7and13).toBeDefined();
+      expect('han' in result).toBe(false);
+      expect('fu' in result).toBe(false);
+      expect('ten' in result).toBe(false);
+    } else {
+      throw new Error('Expected noten result');
+    }
+  });
+
+  it('should discriminate ErrorResult with type field', () => {
+    const riichi = new Riichi('123');
+    const result = riichi.calc();
+
+    if (result.type === CalcResultType.ERROR) {
+      expect(result.isAgari).toBe(false);
+      expect(result.error).toBe(true);
+      expect('han' in result).toBe(false);
+      expect('hairi' in result).toBe(false);
+    } else {
+      throw new Error('Expected error result');
+    }
+  });
+
+  it('should work with switch statement', () => {
+    const riichi = new Riichi('112233456789m11s');
+    const result = riichi.calc();
+
+    switch (result.type) {
+      case CalcResultType.AGARI:
+        expect(result.ten).toBe(7900);
+        break;
+      case CalcResultType.NOTEN:
+        throw new Error('Should not be noten');
+      case CalcResultType.ERROR:
+        throw new Error('Should not be error');
+    }
   });
 });

--- a/src/core/yaku/TileConverter.test.ts
+++ b/src/core/yaku/TileConverter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Riichi } from './Riichi';
+import { assertAgariResult } from './Riichi.test';
 import { ConvertFull } from './TileConverter';
 
 describe('Basic Examples', () => {
@@ -39,6 +40,7 @@ describe('Basic Examples', () => {
 
     const riichi = new Riichi(fullString);
     const result = riichi.calc();
+    assertAgariResult(result);
     expect(result.isAgari).toBe(true);
     expect(result.yakuman).toBe(0);
     expect(result.han).toBe(4);

--- a/src/core/yaku/YakuHelpers.ts
+++ b/src/core/yaku/YakuHelpers.ts
@@ -1,9 +1,4 @@
-import type {
-  YakuName,
-  YakuValue,
-  YakuEntry,
-  RiichiCalcResult,
-} from './YakuTypes';
+import type { YakuName, YakuValue, YakuEntry, AgariResult } from './YakuTypes';
 
 export function toStringYakuName(name: YakuName): string {
   return name;
@@ -73,7 +68,7 @@ export function parseYakuString(str: string): YakuValue {
 }
 
 export function paymentToArrays(
-  payment: RiichiCalcResult['payment'],
+  payment: AgariResult['payment'],
   isOya: boolean,
 ): { oya: number[]; ko: number[] } {
   if (payment.type === 'tsumo') {

--- a/src/core/yaku/YakuTypes.ts
+++ b/src/core/yaku/YakuTypes.ts
@@ -104,9 +104,36 @@ export interface HairiResult {
   [key: string]: Map<string, number> | number | undefined;
 }
 
-export interface RiichiCalcResult {
+export enum CalcResultType {
+  ERROR = 'error',
+  NOTEN = 'noten',
+  AGARI = 'agari',
+}
+
+export interface BaseCalcResult {
+  type: CalcResultType;
   isAgari: boolean;
   error: boolean;
+}
+
+export interface ErrorResult extends BaseCalcResult {
+  type: CalcResultType.ERROR;
+  isAgari: false;
+  error: true;
+}
+
+export interface NotenResult extends BaseCalcResult {
+  type: CalcResultType.NOTEN;
+  isAgari: false;
+  error: false;
+  hairi: HairiResult;
+  hairi7and13: HairiResult;
+}
+
+export interface AgariResult extends BaseCalcResult {
+  type: CalcResultType.AGARI;
+  isAgari: true;
+  error: false;
   yakuman: number;
   yaku: YakuEntry[];
   han: number;
@@ -128,6 +155,6 @@ export interface RiichiCalcResult {
         type: 'ron';
         amount: number;
       };
-  hairi?: HairiResult;
-  hairi7and13?: HairiResult;
 }
+
+export type CalcResult = ErrorResult | NotenResult | AgariResult;


### PR DESCRIPTION
close #10 
Split the return type to 3 and defined a discriminated union
User will be able to know the type from the type field of the return value